### PR TITLE
First draft.

### DIFF
--- a/Handler.ts
+++ b/Handler.ts
@@ -1,5 +1,11 @@
 import * as http from "cloudly-http"
+import * as platform from "./platform"
 
 export type Handler<T> =
-	| ((request: http.Request, context: T) => Promise<http.Response.Like | any>)
-	| ((request: http.Request) => Promise<http.Response.Like | any>)
+	| ((
+			request: http.Request | (platform.Request & { parameter: Record<string, string | undefined> }),
+			context: T
+	  ) => Promise<http.Response.Like | platform.Response | any>)
+	| ((
+			request: http.Request | (platform.Request & { parameter: Record<string, string | undefined> })
+	  ) => Promise<http.Response.Like | platform.Response | any>)

--- a/Route.ts
+++ b/Route.ts
@@ -1,22 +1,47 @@
 import "urlpattern-polyfill"
 import * as http from "cloudly-http"
 import { Handler } from "./Handler"
+import * as platform from "./platform"
 
 export class Route<T> {
-	private constructor(readonly pattern: URLPattern, readonly methods: http.Method[], readonly handler: Handler<T>) {}
-	match(request: http.Request, ...alternatePrefix: string[]): http.Request | undefined {
-		let path = request.url.pathname
-		const prefix = alternatePrefix.find(prefix => path.startsWith(prefix))
-		if (prefix)
-			path = path.substring(prefix.length)
-		const match = this.pattern.exec({ pathname: path })
-		return (match && { ...request, parameter: match?.pathname.groups || {} }) || undefined
+	private constructor(
+		readonly pattern: URLPattern,
+		readonly methods: http.Method[],
+		readonly handler: Handler<T>,
+		readonly parse: boolean
+	) {}
+	match(
+		request: http.Request | platform.Request,
+		...alternatePrefix: string[]
+	): http.Request | (platform.Request & { parameter: Record<string, string | undefined> }) | undefined {
+		if (http.Request.is(request) || (this.parse && (request = http.Request.from(request)))) {
+			let path = request.url.pathname
+			const prefix = alternatePrefix.find(prefix => path.startsWith(prefix))
+			if (prefix)
+				path = path.substring(prefix.length)
+			const match = this.pattern.exec({ pathname: path })
+			return (match && { ...request, parameter: match?.pathname.groups || {} }) || undefined
+		} else {
+			const url = new URL(request.url)
+			let path = url.pathname
+			const prefix = alternatePrefix.find(prefix => path.startsWith(prefix))
+			if (prefix)
+				path = path.substring(prefix.length)
+			const match = this.pattern.exec({ pathname: path })
+			return (match && { ...request, parameter: match?.pathname.groups || {} }) || undefined
+		}
 	}
-	static create<T>(method: http.Method | http.Method[], pattern: URLPattern | string, handler: Handler<T>): Route<T> {
+	static create<T>(
+		method: http.Method | http.Method[],
+		pattern: URLPattern | string,
+		handler: Handler<T>,
+		parse = true
+	): Route<T> {
 		return new Route(
 			typeof pattern == "string" ? new URLPattern({ pathname: pattern }) : pattern,
 			Array.isArray(method) ? method : [method],
-			handler
+			handler,
+			parse
 		)
 	}
 }

--- a/Router.spec.ts
+++ b/Router.spec.ts
@@ -1,11 +1,14 @@
 import "isomorphic-fetch"
 import * as http from "cloudly-http"
 import * as cloudRouter from "./index"
+import * as platform from "./platform"
 
 describe("Router", () => {
 	it("create", () => {
 		const router = new cloudRouter.Router()
-		router.add("GET", "/test", async (request: http.Request) => request.url.pathname)
+		router.add("GET", "/test", async (request: http.Request | platform.Request) =>
+			typeof request.url == "string" ? new URL(request.url).pathname : request.url.pathname
+		)
 		expect(router).toMatchObject({
 			origin: ["*"],
 			routes: [
@@ -18,14 +21,18 @@ describe("Router", () => {
 	})
 	it("handle", async () => {
 		const router = new cloudRouter.Router()
-		router.add("GET", "/test", async (request: http.Request) => request.url.pathname)
+		router.add("GET", "/test", async (request: http.Request | platform.Request) =>
+			typeof request.url == "string" ? new URL(request.url).pathname : request.url.pathname
+		)
 		expect(await router.handle(http.Request.create("https://example.com/test"), {})).toMatchObject({
 			body: "/test",
 		})
 	})
 	it("alternate prefix", async () => {
 		const router = new cloudRouter.Router("/api")
-		router.add("GET", "/test", async (request: http.Request) => request.url.pathname)
+		router.add("GET", "/test", async (request: http.Request | platform.Request) =>
+			typeof request.url == "string" ? new URL(request.url).pathname : request.url.pathname
+		)
 		expect(await router.handle(http.Request.create("https://example.com/api/test"), {})).toMatchObject({
 			body: "/api/test",
 		})
@@ -33,7 +40,9 @@ describe("Router", () => {
 	it("custom allow headers on options", async () => {
 		const router = new cloudRouter.Router()
 		router.allowedHeaders.push("X-Auth-Token")
-		router.add("POST", "/test", async (request: http.Request) => request.url.pathname)
+		router.add("POST", "/test", async (request: http.Request | platform.Request) =>
+			typeof request.url == "string" ? new URL(request.url).pathname : request.url.pathname
+		)
 		expect(
 			await router.handle(http.Request.create({ method: "OPTIONS", url: "https://example.com/test" }), {})
 		).toMatchObject({

--- a/platform.ts
+++ b/platform.ts
@@ -1,0 +1,7 @@
+const PlatformRequest = typeof Request != "undefined" ? Request : globalThis.Request
+type PlatformRequest = Request
+
+const PlatformResponse = typeof Response != "undefined" ? Response : globalThis.Response
+type PlatformResponse = Response
+
+export { PlatformRequest as Request, PlatformResponse as Response }


### PR DESCRIPTION
handle() is now able to take globalThis.Requests. The routes choose whether they want parsed requests or not. If the route returns a globalThis.Response it is returned from handle without further modification.